### PR TITLE
Fix external link to LinkedIn

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,9 +119,9 @@
     <div class="container">
         <h3 class="text-center">
             <a href="mailto:paf31@cantab.net"><i class="fa fa-envelope-square"></i></a>
-            <a href="www.linkedin.com/in/paf31"><i class="fa fa-linkedin-square"></i></a>
-            <a href="http://twitter.com/paf31"><i class="fa fa-twitter-square"></i></a>
-            <a href="http://github.com/paf31"><i class="fa fa-github-square"></i></a>
+            <a href="https://www.linkedin.com/in/paf31"><i class="fa fa-linkedin-square"></i></a>
+            <a href="https://twitter.com/paf31"><i class="fa fa-twitter-square"></i></a>
+            <a href="https://github.com/paf31"><i class="fa fa-github-square"></i></a>
         </h3>
         <p class="text-center text-muted"><small>&copy; Phil Freeman 2015</small></p>
     </div>


### PR DESCRIPTION
The LinkedIn link is currently pointing to `http://functorial.com/www.linkedin.com/in/paf31`.

Changing the GH and Twitter links to `https` avoids a redirect. :)
